### PR TITLE
[ Common ] ChipsList 컴포넌트 scroll 이벤트에 throttle 적용하여 최적화

### DIFF
--- a/src/components/common/ChipList/ChipsList.tsx
+++ b/src/components/common/ChipList/ChipsList.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { styled } from "styled-components";
 
 import { IcNextButton } from "../../../assets";
+import { throttle } from "../../../utils/common/throttle";
 
 import Chip from "./Chip";
 import { ChipsListProps } from "./types/chipsListType";
@@ -41,6 +42,8 @@ function ChipsList({ chipsTextList }: ChipsListProps) {
     setIsEnd(currentScrollPos >= maxScrollLeft);
   };
 
+  const throttledScroll = useMemo(() => throttle(handleScroll, 200), []);
+
   return (
     <ChipsListWrapper>
       {!isStart && <LeftBlurBox />}
@@ -55,7 +58,7 @@ function ChipsList({ chipsTextList }: ChipsListProps) {
           <IcNextButton />
         </RightButton>
       )}
-      <ChipsListBox ref={chipsListBoxRef} onScroll={handleScroll}>
+      <ChipsListBox ref={chipsListBoxRef} onScroll={throttledScroll}>
         {chipsTextList.map((buttonText: string, idx: number) => (
           <Chip
             key={`chip-${idx}`}

--- a/src/utils/common/throttle.ts
+++ b/src/utils/common/throttle.ts
@@ -1,0 +1,36 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+type ThrottledFunction<T extends (...args: any[]) => any> = {
+  (...args: Parameters<T>): void;
+  cancel: () => void;
+};
+
+export const throttle = <T extends (...args: any[]) => any>(func: T, delay: number): ThrottledFunction<T> => {
+  let lastCallTime = 0;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const throttled = (...args: Parameters<T>): void => {
+    const nowTime = Date.now();
+
+    if (nowTime - lastCallTime < delay) {
+      if (timeoutId) clearTimeout(timeoutId);
+      timeoutId = setTimeout(
+        () => {
+          lastCallTime = nowTime;
+          func(...args);
+        },
+        delay - (nowTime - lastCallTime)
+      );
+    } else {
+      lastCallTime = nowTime;
+      func(...args);
+    }
+  };
+
+  throttled.cancel = () => {
+    if (timeoutId) clearTimeout(timeoutId);
+  };
+
+  return throttled;
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #44

## ✅ 작업 내용

- [x] ChipsList 컴포넌트 scroll 이벤트에 throttle 적용하여 최적화

## 📸 스크린샷 / GIF / Link
- throttle 적용 전 좌우 왕복 시 스크롤 이벤트 핸들러 호출 횟수 - 166회

https://github.com/NOW-SOPT-CDSP-TEAM-WEB4/Notefolio-Client/assets/60962533/b9407d41-545a-46dd-b557-16ab0670fd36

- throttle 적용 후 좌우 왕복 시 스크롤 이벤트 핸들러 호출 횟수 - 12회

https://github.com/NOW-SOPT-CDSP-TEAM-WEB4/Notefolio-Client/assets/60962533/d755e7c7-816d-4faa-a734-4352c851a088





## 📌 이슈 사항
스크롤 이벤트 핸들러가 스크롤을 하는 순간마다 계속 호출되어 과한 호출로 성능이 저하되는 것을 확인해서 throttle 함수를 직접 구현하여 delay만큼의 시간동안 이벤트 핸들러가 최대 1번만 호출되도록 최적화를 진행하였습니다!!
