### PR TITLE
[ Community ] 프로그램 전체 조회 GET API 연동

### DIFF
--- a/src/apis/Community/getProgram.tsx
+++ b/src/apis/Community/getProgram.tsx
@@ -1,0 +1,10 @@
+import { api } from "../../libs/api";
+
+export const getProgram = async () => {
+  try {
+    const res = await api.get("/programs");
+    return res.data.data.programs;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/components/Community/ProgramSection/ProgramItem.tsx
+++ b/src/components/Community/ProgramSection/ProgramItem.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 import { ProgramItemProps } from "../../../types/Community/communityProps";
 
 function ProgramItem({ id, title, content, date, online }: ProgramItemProps) {
-  console.log(id, title, content);
   return (
     <ProgramItemWrapper>
       <ProgramItemContainer key={id}>

--- a/src/components/Community/ProgramSection/ProgramItem.tsx
+++ b/src/components/Community/ProgramSection/ProgramItem.tsx
@@ -2,11 +2,12 @@ import styled from "styled-components";
 
 import { ProgramItemProps } from "../../../types/Community/communityProps";
 
-function ProgramItem({ programId, title, content, date, online, src }: ProgramItemProps) {
+function ProgramItem({ id, title, content, date, online }: ProgramItemProps) {
+  console.log(id, title, content);
   return (
     <ProgramItemWrapper>
-      <ProgramItemContainer key={programId}>
-        <ProgramImg src={src} />
+      <ProgramItemContainer key={id}>
+        <ProgramImg src={`/src/assets/img/img_program_${id}.png`} />
         <Online online={online}>{online ? "실시간 온라인" : "오프라인"}</Online>
         <Title>{title}</Title>
         <Content>{content}</Content>

--- a/src/components/Community/ProgramSection/ProgramSection.tsx
+++ b/src/components/Community/ProgramSection/ProgramSection.tsx
@@ -94,4 +94,6 @@ const Title = styled.div`
 const ProgramContainer = styled.section`
   display: flex;
   flex-direction: row;
+
+  gap: 2.4rem;
 `;

--- a/src/components/Community/ProgramSection/ProgramSection.tsx
+++ b/src/components/Community/ProgramSection/ProgramSection.tsx
@@ -1,54 +1,45 @@
+import { useState, useEffect } from "react";
+
 import { styled } from "styled-components";
+
+import { getProgram } from "../../../apis/Community/getProgram";
+import { ProgramItemProps } from "../../../types/Community/communityProps";
 
 import ProgramItem from "./ProgramItem";
 
-// api 연결할 때 여기서 워크샵 목록 ProgramItem으로 props 전달해주기
-
 function ProgramSection() {
-  const communityProgram1 = [
-    {
-      programId: 1,
-      title: "제목1",
-      content: "내용이 들어갑니다~",
-      date: "2022/01/30 (5시)",
-      online: true,
-      src: "/src/assets/img/img_program_1.png",
-    },
-    {
-      programId: 2,
-      title: "제목2",
-      content: "내용이 들어갑니다~",
-      date: "2022/01/30 (5시)",
-      online: false,
-      src: "/src/assets/img/img_program_2.png",
-    },
-  ];
+  const [programList1, setProgramList1] = useState<ProgramItemProps[]>([]);
 
-  const communityProgram2 = [
-    {
-      programId: 3,
-      title: "제목1",
-      content: "내용이 들어갑니다~",
-      date: "2022/01/30 (5시)",
-      online: true,
-      src: "/src/assets/img/img_program_3.png",
-    },
-    {
-      programId: 4,
-      title: "제목2",
-      content: "내용이 들어갑니다~",
-      date: "2022/01/30 (5시)",
-      online: false,
-      src: "/src/assets/img/img_program_4.png",
-    },
-  ];
+  const [programList2, setProgramList2] = useState<ProgramItemProps[]>([]);
+
+  useEffect(() => {
+    const getProgramList = async () => {
+      try {
+        const apiGet = await getProgram();
+        const newList1 = [];
+        const newList2 = [];
+        for (let i = 0; i < 4; i++) {
+          const apiItem = apiGet.find((api: ProgramItemProps) => api.id === i + 1);
+          {
+            i < 2 ? newList1.push(apiItem) : newList2.push(apiItem);
+          }
+        }
+        setProgramList1(newList1);
+        setProgramList2(newList2);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    getProgramList();
+  }, []);
 
   return (
     <ProgramSectionWrapper>
       <ProgramOutContainer>
         <Title>새롭게 오픈한 프로그램 💡</Title>
         <ProgramContainer>
-          {communityProgram1.map((item) => (
+          {programList1.map((item) => (
             <ProgramItem key={item.title} {...item} />
           ))}
         </ProgramContainer>
@@ -56,7 +47,7 @@ function ProgramSection() {
       <ProgramOutContainer>
         <Title>프로덕트 디자이너로 성장하기</Title>
         <ProgramContainer>
-          {communityProgram2.map((item) => (
+          {programList2.map((item) => (
             <ProgramItem key={item.title} {...item} />
           ))}
         </ProgramContainer>

--- a/src/types/Community/communityProps.ts
+++ b/src/types/Community/communityProps.ts
@@ -1,5 +1,5 @@
 export interface ProgramItemProps {
-  programId: number;
+  id: number;
   title: string;
   content: string;
   date: string;


### PR DESCRIPTION
## 🔥 Related Issues

- close #67 

## ✅ 작업 내용

- [x] 프로그램 전체 조회 GET API 연동하기

## 📸 스크린샷 / GIF / Link
![image](https://github.com/NOW-SOPT-CDSP-TEAM-WEB4/Notefolio-Client/assets/66528589/e22c89f4-2891-4a4f-ae29-5e854eec774e)


## 📌 이슈 사항
`ProgramSection.tsx` 내의

```javascript
const [programList1, setProgramList1] = useState<ProgramItemProps[]>([]);

  const [programList2, setProgramList2] = useState<ProgramItemProps[]>([]);

  useEffect(() => {
    const getProgramList = async () => {
      try {
        const apiGet = await getProgram();
        const newList1 = [];
        const newList2 = [];
        for (let i = 0; i < 4; i++) {
          const apiItem = apiGet.find((api: ProgramItemProps) => api.id === i + 1);
          {
            i < 2 ? newList1.push(apiItem) : newList2.push(apiItem);
          }
        }
        setProgramList1(newList1);
        setProgramList2(newList2);
      } catch (error) {
        console.log(error);
      }
    };

    getProgramList();
  }, []);
```

가 API 연결 관련 코드로, 빈 배열 내에 API 값들을 받아 push하는 방식으로 진행하였습니다!
